### PR TITLE
chore(deps): bump ioCucumberVersion from 6.1.0 to 6.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     mapstructVersion = "1.3.1.Final"
     lombokVersion = "1.18.12"
     wireMockVersion = "2.25.1"
-    ioCucumberVersion = "6.1.0"
+    ioCucumberVersion = "6.1.1"
     swaggerVersion = "2.9.2"
     jacocoVersion = "0.8.5"
 }


### PR DESCRIPTION
Bumps `ioCucumberVersion` from 6.1.0 to 6.1.1.

Updates `cucumber-java` from 6.1.0 to 6.1.1
- [Release notes](https://github.com/cucumber/cucumber-jvm/releases)
- [Changelog](https://github.com/cucumber/cucumber-jvm/blob/master/CHANGELOG.md)
- [Commits](https://github.com/cucumber/cucumber-jvm/compare/v6.1.0...v6.1.1)

Updates `cucumber-junit` from 6.1.0 to 6.1.1
- [Release notes](https://github.com/cucumber/cucumber-jvm/releases)
- [Changelog](https://github.com/cucumber/cucumber-jvm/blob/master/CHANGELOG.md)
- [Commits](https://github.com/cucumber/cucumber-jvm/compare/v6.1.0...v6.1.1)

Updates `cucumber-spring` from 6.1.0 to 6.1.1
- [Release notes](https://github.com/cucumber/cucumber-jvm/releases)
- [Changelog](https://github.com/cucumber/cucumber-jvm/blob/master/CHANGELOG.md)
- [Commits](https://github.com/cucumber/cucumber-jvm/compare/v6.1.0...v6.1.1)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>